### PR TITLE
refactor: replace make with $(MAKE) in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,9 @@ MODULE_NAME = ideapad-laptop-tb
 obj-m := $(MODULE_NAME).o
 
 all:
-	make -C $(KERNEL_DIR)/build/ M=$(PWD) modules
+	$(MAKE) -C $(KERNEL_DIR)/build/ M=$(PWD) modules
 clean:
-	make -C $(KERNEL_DIR)/build/ M=$(PWD) clean
+	$(MAKE) -C $(KERNEL_DIR)/build/ M=$(PWD) clean
 
 install:
 	sudo insmod ideapad-laptop-tb.ko


### PR DESCRIPTION
According to [GNU Make Manual](https://www.gnu.org/software/make/manual/html_node/MAKE-Variable.html), recursive make commands should always use the variable `MAKE`, not the explicit command name `make`.